### PR TITLE
add keytype in calculateSimMatrix

### DIFF
--- a/R/rrvgo.R
+++ b/R/rrvgo.R
@@ -23,7 +23,8 @@
 #' @export
 calculateSimMatrix <- function(x,
                                orgdb,
-                               semdata=GOSemSim::godata(orgdb, ont=ont),
+                               keytype="ENTREZID",
+                               semdata=GOSemSim::godata(orgdb, ont=ont, keytype=keytype),
                                ont=c("BP", "MF", "CC"),
                                method=c("Resnik", "Lin", "Rel", "Jiang", "Wang")) {
  


### PR DESCRIPTION
Hi ssayols, thanks for your great work!

I work in non-model species and I usually make Orgdb packages by AnnotationForge by myself. Some non-model species don't have ENTREZID or ENTREZID is not the newest annotations. So sometimes we would like to select our own keytype.

GoSemSim has the function to select keytype so it seems easy to implement like this PR.

I check this PR works in my own org.db project. 